### PR TITLE
Add deployment report generation with JSON/JUnit output

### DIFF
--- a/src/SalesforceClient.ts
+++ b/src/SalesforceClient.ts
@@ -4,7 +4,8 @@ import { AuthService } from './services/AuthService.js';
 import { DeployService } from './services/DeployService.js';
 import { MDAPIService } from './services/MDAPIService.js';
 import { ArchiverService } from './services/ArchiverService.js';
-import { DeployOptions, DeployResult } from 'types/deployment.type.js';
+import { ReportService } from './services/ReportService.js';
+import type { DeployOptions, DeployResult } from 'types/deployment.type.js';
 import path from 'path';
 import fs from 'fs';
 
@@ -14,6 +15,7 @@ export class SalesforceClient {
 	private deployService: DeployService;
 	private mdapiService: MDAPIService;
 	private archiverService: ArchiverService;
+	private reportService: ReportService;
 
 	constructor(config: CommandArgsConfig) {
 		this.config = config;
@@ -21,6 +23,7 @@ export class SalesforceClient {
 		this.deployService = new DeployService(config);
 		this.mdapiService = new MDAPIService(config);
 		this.archiverService = new ArchiverService(config);
+		this.reportService = new ReportService();
 	}
 
 	async deploy(options: Partial<DeployOptions> = {}): Promise<DeployResult> {
@@ -29,15 +32,10 @@ export class SalesforceClient {
 			console.log('🔐 Authenticating with Salesforce...');
 			await this.authService.authenticate();
 
-			// Step 2: Convert to MDAPI format
-			// console.log('🔄 Converting to MDAPI format...');
 			const runTests = await this.mdapiService.convertToMDAPI(this.config.exclude);
-
 			const files = await fs.promises.readdir(this.config.cliOuputFolder);
-			const hasPackageXml = files.some(file => file === 'package.xml');
-			console
+			const hasPackageXml = files.some((file) => file === 'package.xml');
 
-			// Step 3: Handle main deployment
 			const deploymentOptions = { ...options, runTests };
 			let mainDeployId: string;
 
@@ -45,24 +43,21 @@ export class SalesforceClient {
 				console.log('📦 Preparing deployment package...', this.config.output);
 				await this.archiverService.zipDirectory(this.config.cliOuputFolder, this.config.output);
 
-
 				console.log('🚀 Initiating deployment...');
 				mainDeployId = await this.deployService.initiateDeployment(this.config.output, deploymentOptions);
 				console.log('📝 Main deployment initiated with ID:', mainDeployId);
 
-				// Step 5: Poll for deployment status
 				console.log('⏳ Waiting for deployment completion...');
 				console.time('⏳⏳ Deployment time ⏳⏳');
 				const mainDeployResult = await this.deployService.pollDeploymentStatus(mainDeployId);
 				console.log('📊 Main deployment result:', mainDeployResult.status);
 				console.timeEnd('⏳⏳ Deployment time ⏳⏳');
+				await this.generateReport(mainDeployResult);
 
 				return mainDeployResult;
 			}
 
-			// Step 4: Handle destructive changes
 			const destructivePath = path.join(this.config.cliOuputFolder, 'destructiveChanges', 'destructiveChanges.xml');
-
 			let destructiveDeployId: string | undefined;
 
 			if (this.fileExists(destructivePath)) {
@@ -76,21 +71,16 @@ export class SalesforceClient {
 					console.log('🚀 Destructive changes deployment initiated with ID:', destructiveDeployId);
 				} catch (error) {
 					console.error('❌ Error processing destructive changes:', error);
-					// Continue with main deployment even if destructive deployment fails
 				}
 			} else {
 				console.log('ℹ️  No destructive changes found');
 			}
 
-
-			// if (mainDeployResult.status === 'Failed') process.exit(1);
-
-			// If there was a destructive deployment, wait for it too
 			if (destructiveDeployId) {
 				console.log('⏳ Waiting for destructive changes deployment...');
 				try {
 					const destructiveResult = await this.deployService.pollDeploymentStatus(destructiveDeployId);
-					// console.log('📊 Destructive changes deployment result:', destructiveResult.status);
+					await this.generateReport(destructiveResult);
 					return destructiveResult;
 				} catch (error) {
 					console.error('❌ Error in destructive changes deployment:', error);
@@ -104,7 +94,21 @@ export class SalesforceClient {
 		}
 	}
 
-	// Helper method to check file existence
+	private async generateReport(deployResult: DeployResult): Promise<void> {
+		await this.reportService.writeDeploymentReport(
+			{
+				summary: this.deployService.serializeSummary(deployResult),
+				componentFailures: this.deployService.serializeComponentFailures(deployResult),
+				testFailures: this.deployService.serializeTestFailures(deployResult),
+			},
+			{
+				reportFormat: this.config.reportFormat,
+				reportPath: this.config.reportPath,
+				emitConsoleSummary: true,
+			}
+		);
+	}
+
 	private fileExists(filePath: string): boolean {
 		return fs.existsSync(filePath);
 	}

--- a/src/SalesforceClient.ts
+++ b/src/SalesforceClient.ts
@@ -95,18 +95,23 @@ export class SalesforceClient {
 	}
 
 	private async generateReport(deployResult: DeployResult): Promise<void> {
-		await this.reportService.writeDeploymentReport(
-			{
-				summary: this.deployService.serializeSummary(deployResult),
-				componentFailures: this.deployService.serializeComponentFailures(deployResult),
-				testFailures: this.deployService.serializeTestFailures(deployResult),
-			},
-			{
-				reportFormat: this.config.reportFormat,
-				reportPath: this.config.reportPath,
-				emitConsoleSummary: true,
-			}
-		);
+		try {
+			await this.reportService.writeDeploymentReport(
+				{
+					summary: this.deployService.serializeSummary(deployResult),
+					componentFailures: this.deployService.serializeComponentFailures(deployResult),
+					testFailures: this.deployService.serializeTestFailures(deployResult),
+				},
+				{
+					reportFormat: this.config.reportFormat,
+					reportPath: this.config.reportPath,
+					emitConsoleSummary: true,
+				}
+			);
+		} catch (error) {
+			const reportError = error instanceof Error ? error.message : error;
+			console.warn('⚠️ Failed to generate deployment report:', reportError);
+		}
 	}
 
 	private fileExists(filePath: string): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import config from './config.js';
 import { SalesforceClient } from './SalesforceClient.js';
 import type { CommandArgsConfig } from './types/config.type.js';
-import type { DeployOptions } from './types/deployment.type.js';
+import type { DeployOptions, ReportFormat } from './types/deployment.type.js';
 
 class CLI {
 	private program: Command;
@@ -35,7 +35,9 @@ class CLI {
 			.option('-r, --targetBranch <targetBranch>', 'Target branch or git ref for delta comparison', this.config.targetBranch)
 			.option('-v, --validateOnly', 'Validate only, do not deploy')
 			.option('-x, --exclude <types...>', 'List of metadata types to exclude')
-			.option('-t, --testLevel <level>', 'Specifies which tests are run as part of a deployment', 'NoTestRun');
+			.option('-t, --testLevel <level>', 'Specifies which tests are run as part of a deployment', 'NoTestRun')
+			.option('--reportFormat <json|junit|both>', 'Deployment report format', this.config.reportFormat ?? 'json')
+			.option('--reportPath <path>', 'Directory path for generated deployment reports', this.config.reportPath ?? './reports');
 	}
 
 	private setupCommands(): void {
@@ -89,6 +91,7 @@ class CLI {
 
 	private getUpdatedConfig(options: any): CommandArgsConfig {
 		const updatedConfig = { ...this.config, ...options };
+		updatedConfig.reportFormat = this.parseReportFormat(updatedConfig.reportFormat);
 
 		// Update instance URL and test level for production environment
 		if (options.env?.toUpperCase() === 'PRODUCTION') {
@@ -102,6 +105,18 @@ class CLI {
 		console.log('Username :', updatedConfig.username);
 		// console.log('Using configuration:', updatedConfig);
 		return updatedConfig;
+	}
+
+
+	private parseReportFormat(value?: string): ReportFormat {
+		const allowedFormats: ReportFormat[] = ['json', 'junit', 'both'];
+		const normalizedValue = (value ?? 'json').toLowerCase() as ReportFormat;
+
+		if (!allowedFormats.includes(normalizedValue)) {
+			throw new Error(`Invalid report format: ${value}. Allowed values: ${allowedFormats.join(', ')}`);
+		}
+
+		return normalizedValue;
 	}
 
 	private validateConfig(config: CommandArgsConfig): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,9 @@ const config: CommandArgsConfig = {
   
   // Test coverage configuration
   coverageJson: './ApexTestCoverage.json',
-  runTests: []
+  runTests: [],
+  reportFormat: 'json',
+  reportPath: './reports'
 };
 
 export default config;

--- a/src/services/DeployService.ts
+++ b/src/services/DeployService.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { BaseService } from './BaseService.js';
-import type { DeployOptions, DeployResult } from '../types/deployment.type.js';
+import type { DeployOptions, DeployResult, DeploymentComponentFailure, DeploymentSummary, DeploymentTestFailure } from '../types/deployment.type.js';
 
 export class DeployService extends BaseService {
   async quickDeploy(deploymentId: string): Promise<DeployResult> {
@@ -62,17 +62,17 @@ export class DeployService extends BaseService {
         console.log(`Running Test Status: ${status.numberTestsCompleted} / ${status.numberTestsTotal}`);
       }
       // if (status.numberTestErrors > 0 || status.numberComponentErrors > 0) { // status.details?.componentFailures.length > 0
-      if(status.status === 'Failed') {
+      if (status.status === 'Failed') {
         console.log('🚨📢🔔 DEPLOYMENT FAILED 🚨📢🔔');
-        // Create a new array with only the selected properties
-        const failedTests = status.details.runTestResult?.failures.map(({ stackTrace }) => ({ stackTrace }));
-        if (failedTests?.length) {
+        const failedTests = this.serializeTestFailures(status).map(({ stackTrace }) => ({ stackTrace }));
+
+        if (failedTests.length > 0) {
           console.table(failedTests);
         }
-        if (status.details?.componentFailures) {
-          const failedComponenets = status.details?.componentFailures.map(({ fileName, fullName, problem }) => ({ fileName, fullName, problem }));
-          console.table(failedComponenets);
-          // console.log('Failed Components:', status.details.componentFailures);
+
+        const failedComponents = this.serializeComponentFailures(status).map(({ fileName, fullName, problem }) => ({ fileName, fullName, problem }));
+        if (failedComponents.length > 0) {
+          console.table(failedComponents);
         }
       }
 
@@ -85,6 +85,34 @@ export class DeployService extends BaseService {
     }
 
     throw new Error('Deployment timed out');
+  }
+
+
+  serializeSummary(status: DeployResult): DeploymentSummary {
+    return {
+      deploymentId: status.id,
+      status: status.status,
+      done: status.done,
+      components: {
+        deployed: status.numberComponentsDeployed ?? 0,
+        total: status.numberComponentsTotal ?? 0,
+        errors: status.numberComponentErrors ?? 0,
+      },
+      tests: {
+        completed: status.numberTestsCompleted ?? 0,
+        total: status.numberTestsTotal ?? 0,
+        errors: status.numberTestErrors ?? 0,
+      },
+      stateDetail: status.stateDetail,
+    };
+  }
+
+  serializeComponentFailures(status: DeployResult): DeploymentComponentFailure[] {
+    return status.details?.componentFailures ?? [];
+  }
+
+  serializeTestFailures(status: DeployResult): DeploymentTestFailure[] {
+    return status.details?.runTestResult?.failures ?? [];
   }
 
   private async getDeploymentStatus(deployId: string): Promise<DeployResult> {

--- a/src/services/ReportService.ts
+++ b/src/services/ReportService.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import path from 'path';
+import type { ReportFormat, DeploymentReport, DeploymentSummary, DeploymentComponentFailure, DeploymentTestFailure } from '../types/deployment.type.js';
+
+interface ReportWriteOptions {
+	reportFormat?: ReportFormat;
+	reportPath?: string;
+	emitConsoleSummary?: boolean;
+}
+
+interface DeploymentReportPayload {
+	summary: DeploymentSummary;
+	componentFailures: DeploymentComponentFailure[];
+	testFailures: DeploymentTestFailure[];
+}
+
+export class ReportService {
+	async writeDeploymentReport(payload: DeploymentReportPayload, options: ReportWriteOptions = {}): Promise<string[]> {
+		const reportFormat = options.reportFormat ?? 'json';
+		const reportPath = options.reportPath ?? './reports';
+		const generatedAt = new Date().toISOString();
+		const report: DeploymentReport = {
+			generatedAt,
+			summary: payload.summary,
+			componentFailures: payload.componentFailures,
+			testFailures: payload.testFailures,
+		};
+
+		await fs.promises.mkdir(reportPath, { recursive: true });
+
+		const baseFileName = `deployment-${payload.summary.deploymentId}-${generatedAt.replace(/[:.]/g, '-')}`;
+		const outputFiles: string[] = [];
+
+		if (reportFormat === 'json' || reportFormat === 'both') {
+			const jsonPath = path.join(reportPath, `${baseFileName}.json`);
+			await fs.promises.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+			outputFiles.push(jsonPath);
+		}
+
+		if (reportFormat === 'junit' || reportFormat === 'both') {
+			const junitPath = path.join(reportPath, `${baseFileName}.xml`);
+			const junitXml = this.generateJUnitReport(report);
+			await fs.promises.writeFile(junitPath, junitXml, 'utf8');
+			outputFiles.push(junitPath);
+		}
+
+		if (options.emitConsoleSummary) {
+			this.printSummary(report.summary, outputFiles);
+		}
+
+		return outputFiles;
+	}
+
+	generateJUnitReport(report: DeploymentReport): string {
+		const testCases = report.testFailures
+			.map(
+				(failure) =>
+					`    <testcase classname="${this.escapeXml(failure.name)}" name="${this.escapeXml(failure.methodName)}">\n` +
+					`      <failure message="${this.escapeXml(failure.message)}">${this.escapeXml(failure.stackTrace)}</failure>\n` +
+					'    </testcase>'
+			)
+			.join('\n');
+
+		const componentCases = report.componentFailures
+			.map(
+				(failure) =>
+					`    <testcase classname="${this.escapeXml(failure.componentType)}" name="${this.escapeXml(failure.fullName)}">\n` +
+					`      <failure message="${this.escapeXml(failure.problemType)}">${this.escapeXml(failure.problem)}</failure>\n` +
+					'    </testcase>'
+			)
+			.join('\n');
+
+		const failureCases = [testCases, componentCases].filter(Boolean).join('\n');
+		const totalFailures = report.testFailures.length + report.componentFailures.length;
+		const totalTests = Math.max(report.summary.tests.total, totalFailures, 1);
+
+		return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="Salesforce Deployment ${this.escapeXml(report.summary.deploymentId)}" tests="${totalTests}" failures="${totalFailures}">\n${failureCases}\n</testsuite>\n`;
+	}
+
+	private printSummary(summary: DeploymentSummary, outputFiles: string[]): void {
+		console.log(`🧾 Deployment report (${summary.status}) generated:`);
+		for (const reportFile of outputFiles) {
+			console.log(` - ${reportFile}`);
+		}
+	}
+
+	private escapeXml(value: string): string {
+		return value
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&apos;');
+	}
+}

--- a/src/services/ReportService.ts
+++ b/src/services/ReportService.ts
@@ -52,29 +52,34 @@ export class ReportService {
 	}
 
 	generateJUnitReport(report: DeploymentReport): string {
-		const testCases = report.testFailures
-			.map(
-				(failure) =>
-					`    <testcase classname="${this.escapeXml(failure.name)}" name="${this.escapeXml(failure.methodName)}">\n` +
-					`      <failure message="${this.escapeXml(failure.message)}">${this.escapeXml(failure.stackTrace)}</failure>\n` +
-					'    </testcase>'
-			)
-			.join('\n');
+		const failedTestCases = report.testFailures.map(
+			(failure) =>
+				`    <testcase classname="${this.escapeXml(failure.name)}" name="${this.escapeXml(failure.methodName)}">\n` +
+				`      <failure message="${this.escapeXml(failure.message)}">${this.escapeXml(failure.stackTrace)}</failure>\n` +
+				'    </testcase>'
+		);
 
-		const componentCases = report.componentFailures
-			.map(
-				(failure) =>
-					`    <testcase classname="${this.escapeXml(failure.componentType)}" name="${this.escapeXml(failure.fullName)}">\n` +
-					`      <failure message="${this.escapeXml(failure.problemType)}">${this.escapeXml(failure.problem)}</failure>\n` +
-					'    </testcase>'
-			)
-			.join('\n');
+		const passedTestCount = Math.max(report.summary.tests.total - report.testFailures.length, 0);
+		const passedTestCases = Array.from({ length: passedTestCount }, (_, index) => `    <testcase classname="ApexTests" name="passed-${index + 1}" />`);
 
-		const failureCases = [testCases, componentCases].filter(Boolean).join('\n');
+		const componentFailureCases = report.componentFailures.map(
+			(failure) =>
+				`    <testcase classname="${this.escapeXml(failure.componentType)}" name="${this.escapeXml(failure.fullName)}">\n` +
+				`      <failure message="${this.escapeXml(failure.problemType)}">${this.escapeXml(failure.problem)}</failure>\n` +
+				'    </testcase>'
+		);
+
+		const testSuiteCases = [...failedTestCases, ...passedTestCases].join('\n');
+		const componentSuiteCases = componentFailureCases.join('\n');
 		const totalFailures = report.testFailures.length + report.componentFailures.length;
-		const totalTests = Math.max(report.summary.tests.total, totalFailures, 1);
 
-		return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuite name="Salesforce Deployment ${this.escapeXml(report.summary.deploymentId)}" tests="${totalTests}" failures="${totalFailures}">\n${failureCases}\n</testsuite>\n`;
+		return (
+			`<?xml version="1.0" encoding="UTF-8"?>\n` +
+			`<testsuites name="Salesforce Deployment ${this.escapeXml(report.summary.deploymentId)}" tests="${report.summary.tests.total + report.componentFailures.length}" failures="${totalFailures}">\n` +
+			`  <testsuite name="Apex Tests" tests="${report.summary.tests.total}" failures="${report.testFailures.length}">\n${testSuiteCases}\n  </testsuite>\n` +
+			`  <testsuite name="Component Failures" tests="${report.componentFailures.length}" failures="${report.componentFailures.length}">\n${componentSuiteCases}\n  </testsuite>\n` +
+			'</testsuites>\n'
+		);
 	}
 
 	private printSummary(summary: DeploymentSummary, outputFiles: string[]): void {

--- a/src/services/__tests__/ReportService.test.ts
+++ b/src/services/__tests__/ReportService.test.ts
@@ -1,0 +1,160 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ReportService } from '../ReportService';
+import { DeployService } from '../DeployService';
+import type { CommandArgsConfig } from '../../types/config.type';
+import type { DeployResult } from '../../types/deployment.type';
+
+describe('ReportService', () => {
+	let reportService: ReportService;
+	let reportDir: string;
+
+	beforeEach(async () => {
+		reportService = new ReportService();
+		reportDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'sf-report-'));
+	});
+
+	afterEach(async () => {
+		await fs.promises.rm(reportDir, { recursive: true, force: true });
+	});
+
+	it('writes a JSON report with expected shape', async () => {
+		const files = await reportService.writeDeploymentReport(
+			{
+				summary: {
+					deploymentId: '0Afxx0000001234',
+					status: 'Succeeded',
+					done: true,
+					components: { deployed: 10, total: 10, errors: 0 },
+					tests: { completed: 5, total: 5, errors: 0 },
+				},
+				componentFailures: [],
+				testFailures: [],
+			},
+			{ reportFormat: 'json', reportPath: reportDir }
+		);
+
+		expect(files).toHaveLength(1);
+		expect(files[0]).toContain('.json');
+
+		const raw = await fs.promises.readFile(files[0], 'utf8');
+		const parsed = JSON.parse(raw);
+		expect(parsed.summary.deploymentId).toBe('0Afxx0000001234');
+		expect(Array.isArray(parsed.componentFailures)).toBe(true);
+		expect(Array.isArray(parsed.testFailures)).toBe(true);
+	});
+
+	it('failed deployments produce non-empty failure sections in JSON and JUnit', async () => {
+		const files = await reportService.writeDeploymentReport(
+			{
+				summary: {
+					deploymentId: '0Afxx0000009999',
+					status: 'Failed',
+					done: true,
+					components: { deployed: 2, total: 4, errors: 2 },
+					tests: { completed: 3, total: 3, errors: 1 },
+					stateDetail: 'Deployment failed',
+				},
+				componentFailures: [
+					{
+						componentType: 'ApexClass',
+						fileName: 'classes/MyClass.cls',
+						fullName: 'MyClass',
+						problem: 'Unexpected token',
+						problemType: 'Error',
+						success: false,
+					},
+				],
+				testFailures: [
+					{
+						name: 'MyClassTest',
+						methodName: 'shouldFail',
+						message: 'Assertion Failed',
+						stackTrace: 'Class.MyClassTest.shouldFail: line 12, column 1',
+					},
+				],
+			},
+			{ reportFormat: 'both', reportPath: reportDir }
+		);
+
+		expect(files).toHaveLength(2);
+		const jsonPath = files.find((file) => file.endsWith('.json'));
+		const xmlPath = files.find((file) => file.endsWith('.xml'));
+		expect(jsonPath).toBeDefined();
+		expect(xmlPath).toBeDefined();
+
+		const rawJson = await fs.promises.readFile(jsonPath!, 'utf8');
+		const parsed = JSON.parse(rawJson);
+		expect(parsed.componentFailures.length).toBeGreaterThan(0);
+		expect(parsed.testFailures.length).toBeGreaterThan(0);
+
+		const rawXml = await fs.promises.readFile(xmlPath!, 'utf8');
+		expect(rawXml).toContain('<failure message="Error">Unexpected token</failure>');
+		expect(rawXml).toContain('testsuite');
+	});
+
+	it('uses DeployService serializers for failed deployment failure sections', () => {
+		const config: CommandArgsConfig = {
+			clientId: 'test-client-id',
+			username: 'test@example.com',
+			instanceUrl: 'https://test.salesforce.com',
+			privateKey: 'test-private-key.pem',
+			accessToken: 'mock-access-token',
+			source: 'src',
+			output: 'deploy.zip',
+			env: 'SANDBOX',
+			baseBranch: 'HEAD~1',
+			targetBranch: 'HEAD',
+			appVersion: '1.0.0',
+			appDescription: 'Test App',
+			sfVersion: '56.0',
+			cliVersion: '1.0.0',
+			cliOuputFolder: '.output',
+			testLevel: 'NoTestRun',
+			coverageJson: 'coverage.json',
+			runTests: [],
+		};
+		const deployService = new DeployService(config);
+		const failedStatus = {
+			id: '0Afxx0000001111',
+			done: true,
+			status: 'Failed',
+			numberComponentsDeployed: 1,
+			numberComponentsTotal: 2,
+			numberComponentErrors: 1,
+			numberTestsCompleted: 1,
+			numberTestsTotal: 1,
+			numberTestErrors: 1,
+			details: {
+				componentFailures: [
+					{
+						componentType: 'ApexTrigger',
+						fileName: 'triggers/Example.trigger',
+						fullName: 'Example',
+						problem: 'Compile error',
+						problemType: 'Error',
+						success: false,
+					},
+				],
+				runTestResult: {
+					numFailures: 1,
+					numTestsRun: 1,
+					totalTime: 50,
+					failures: [
+						{
+							name: 'ExampleTest',
+							methodName: 'failingMethod',
+							message: 'Expected true but got false',
+							stackTrace: 'Class.ExampleTest.failingMethod: line 22, column 1',
+						},
+					],
+				},
+			},
+		} as DeployResult;
+
+		expect(deployService.serializeSummary(failedStatus).status).toBe('Failed');
+		expect(deployService.serializeComponentFailures(failedStatus)).not.toHaveLength(0);
+		expect(deployService.serializeTestFailures(failedStatus)).not.toHaveLength(0);
+	});
+});

--- a/src/services/__tests__/ReportService.test.ts
+++ b/src/services/__tests__/ReportService.test.ts
@@ -91,7 +91,28 @@ describe('ReportService', () => {
 
 		const rawXml = await fs.promises.readFile(xmlPath!, 'utf8');
 		expect(rawXml).toContain('<failure message="Error">Unexpected token</failure>');
-		expect(rawXml).toContain('testsuite');
+		expect(rawXml).toContain('<testsuites name="Salesforce Deployment 0Afxx0000009999"');
+		expect(rawXml).toContain('<testsuite name="Apex Tests" tests="3" failures="1">');
+		expect(rawXml).toContain('<testcase classname="ApexTests" name="passed-1" />');
+	});
+
+	it('creates JUnit testcases for passing tests when there are no failures', () => {
+		const xml = reportService.generateJUnitReport({
+			generatedAt: new Date().toISOString(),
+			summary: {
+				deploymentId: '0Afxx0000007777',
+				status: 'Succeeded',
+				done: true,
+				components: { deployed: 5, total: 5, errors: 0 },
+				tests: { completed: 2, total: 2, errors: 0 },
+			},
+			componentFailures: [],
+			testFailures: [],
+		});
+
+		expect(xml).toContain('<testsuite name="Apex Tests" tests="2" failures="0">');
+		expect(xml).toContain('<testcase classname="ApexTests" name="passed-1" />');
+		expect(xml).toContain('<testcase classname="ApexTests" name="passed-2" />');
 	});
 
 	it('uses DeployService serializers for failed deployment failure sections', () => {

--- a/src/services/__tests__/SalesforceClient.report.test.ts
+++ b/src/services/__tests__/SalesforceClient.report.test.ts
@@ -1,0 +1,61 @@
+import { SalesforceClient } from '../../SalesforceClient';
+import type { CommandArgsConfig } from '../../types/config.type';
+import type { DeployResult } from '../../types/deployment.type';
+
+describe('SalesforceClient report generation', () => {
+	const config: CommandArgsConfig = {
+		clientId: 'test-client-id',
+		username: 'test@example.com',
+		instanceUrl: 'https://test.salesforce.com',
+		privateKey: 'test-private-key.pem',
+		accessToken: 'mock-access-token',
+		source: 'src',
+		output: 'deploy.zip',
+		env: 'SANDBOX',
+		baseBranch: 'HEAD~1',
+		targetBranch: 'HEAD',
+		appVersion: '1.0.0',
+		appDescription: 'Test App',
+		sfVersion: '56.0',
+		cliVersion: '1.0.0',
+		cliOuputFolder: '.output',
+		testLevel: 'NoTestRun',
+		coverageJson: 'coverage.json',
+		runTests: [],
+		reportFormat: 'both',
+		reportPath: './reports',
+	};
+
+	it('does not throw when report writing fails', async () => {
+		const client = new SalesforceClient(config);
+		const deployResult = {
+			id: '0Afxx0000005555',
+			done: true,
+			status: 'Succeeded',
+			numberComponentsDeployed: 4,
+			numberComponentsTotal: 4,
+			numberComponentErrors: 0,
+			numberTestsCompleted: 2,
+			numberTestsTotal: 2,
+			numberTestErrors: 0,
+			details: {
+				componentFailures: [],
+				runTestResult: {
+					numFailures: 0,
+					numTestsRun: 2,
+					totalTime: 12,
+					failures: [],
+				},
+			},
+		} as DeployResult;
+
+		const writeSpy = jest.spyOn((client as any).reportService, 'writeDeploymentReport').mockRejectedValueOnce(new Error('disk full'));
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		await expect((client as any).generateReport(deployResult)).resolves.toBeUndefined();
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith('⚠️ Failed to generate deployment report:', 'disk full');
+
+		warnSpy.mockRestore();
+	});
+});

--- a/src/types/config.type.ts
+++ b/src/types/config.type.ts
@@ -1,3 +1,5 @@
+import type { ReportFormat } from './deployment.type.js';
+
 export interface CommandArgsConfig {
 	source: string;
 	output: string;
@@ -19,4 +21,6 @@ export interface CommandArgsConfig {
 	testLevel: 'NoTestRun' | 'RunLocalTests' | 'RunAllTestsInOrg' | 'RunSpecifiedTests';
 	coverageJson: string;
 	runTests: string[];
+	reportFormat?: ReportFormat;
+	reportPath?: string;
 }

--- a/src/types/deployment.type.ts
+++ b/src/types/deployment.type.ts
@@ -1,42 +1,72 @@
+export type ReportFormat = 'json' | 'junit' | 'both';
+
 export interface DeployOptions {
-    allowMissingFiles: boolean;
-    checkOnly: boolean;
-    testLevel: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
-    runTests?: string[];
-    rollbackOnError: boolean;
-    singlePackage: boolean;
-  }
-  
-  export interface DeployResult {
-    id: string;
-    done: boolean;
-    status: 'Pending' | 'InProgress' | 'Succeeded' | 'SucceededPartial' | 'Failed' | 'Canceled';
-    numberComponentsDeployed: number;
-    numberComponentsTotal: number;
-    numberComponentErrors: number;
-    numberTestsCompleted: number;
-    numberTestsTotal: number;
-    numberTestErrors: number;
-    stateDetail?: string;
-    details: {
-      componentFailures: Array<{
-        componentType: string;
-        fileName: string;
-        fullName: string;
-        problem: string;
-        problemType: string;
-        success: boolean;
-      }>;
-      runTestResult?: {
-        numFailures: number;
-        numTestsRun: number;
-        totalTime: number;
-        failures: Array<{
-          name: string;
-          methodName: string;
-          message: string;
-          stackTrace: string;
-        }>;
-      };
-    };
-  }
+	allowMissingFiles: boolean;
+	checkOnly: boolean;
+	testLevel: 'NoTestRun' | 'RunSpecifiedTests' | 'RunLocalTests' | 'RunAllTestsInOrg';
+	runTests?: string[];
+	rollbackOnError: boolean;
+	singlePackage: boolean;
+}
+
+export interface DeploymentComponentFailure {
+	componentType: string;
+	fileName: string;
+	fullName: string;
+	problem: string;
+	problemType: string;
+	success: boolean;
+}
+
+export interface DeploymentTestFailure {
+	name: string;
+	methodName: string;
+	message: string;
+	stackTrace: string;
+}
+
+export interface DeploymentSummary {
+	deploymentId: string;
+	status: DeployResult['status'];
+	done: boolean;
+	components: {
+		deployed: number;
+		total: number;
+		errors: number;
+	};
+	tests: {
+		completed: number;
+		total: number;
+		errors: number;
+	};
+	stateDetail?: string;
+}
+
+export interface DeploymentReport {
+	generatedAt: string;
+	summary: DeploymentSummary;
+	componentFailures: DeploymentComponentFailure[];
+	testFailures: DeploymentTestFailure[];
+}
+
+export interface DeployResult {
+	id: string;
+	done: boolean;
+	status: 'Pending' | 'InProgress' | 'Succeeded' | 'SucceededPartial' | 'Failed' | 'Canceled';
+	numberComponentsDeployed: number;
+	numberComponentsTotal: number;
+	numberComponentErrors: number;
+	numberTestsCompleted: number;
+	numberTestsTotal: number;
+	numberTestErrors: number;
+	stateDetail?: string;
+	details: {
+		componentFailures: DeploymentComponentFailure[];
+		runTestResult?: {
+			numFailures: number;
+			numTestsRun: number;
+			totalTime: number;
+			failures: DeploymentTestFailure[];
+		};
+	};
+}


### PR DESCRIPTION
### Motivation

- Provide machine-readable and human-friendly reports for deployments so CI systems and engineers can consume results programmatically and via console summaries.
- Surface component and test failures in a structured way and make report format configurable from the CLI.

### Description

- Add CLI flags `--reportFormat <json|junit|both>` and `--reportPath <path>` and validate the selected format during config hydration (`src/cli.ts`, `src/config.ts`, `src/types/config.type.ts`).
- Introduce strongly-typed report models and config types (`DeploymentSummary`, `DeploymentComponentFailure`, `DeploymentTestFailure`, `DeploymentReport`, and `ReportFormat`) in `src/types/deployment.type.ts`.
- Extract status/failure parsing into reusable serializers on `DeployService` (`serializeSummary`, `serializeComponentFailures`, `serializeTestFailures`) and update polling logging to use them (`src/services/DeployService.ts`).
- Add `ReportService` (`src/services/ReportService.ts`) that writes JSON reports, emits JUnit XML, and can print a short console summary with generated file paths.
- Wire report generation into `SalesforceClient` so reports are generated after `pollDeploymentStatus` for both main and destructive deployments (`src/SalesforceClient.ts`).
- Add unit tests for the report writer and serializers (`src/services/__tests__/ReportService.test.ts`).

### Testing

- Ran `npm test -- --runInBand` and all test suites passed: 7 test suites, 194 tests (all green).
- Ran `npm run build` and TypeScript compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e7a6ef3c8327b13a9c88c3f37d43)