### PR TITLE
Add deploy status/cancel commands with CI-friendly failure handling

### DIFF
--- a/src/SalesforceClient.ts
+++ b/src/SalesforceClient.ts
@@ -1,7 +1,7 @@
 // src/SalesforceClient.ts
 import type { CommandArgsConfig } from './types/config.type.js';
 import { AuthService } from './services/AuthService.js';
-import { DeployService } from './services/DeployService.js';
+import { DeployService, NormalizedDeployResponse } from './services/DeployService.js';
 import { MDAPIService } from './services/MDAPIService.js';
 import { ArchiverService } from './services/ArchiverService.js';
 import { DeployOptions, DeployResult } from 'types/deployment.type.js';
@@ -112,5 +112,19 @@ export class SalesforceClient {
 	async quickDeploy(deploymentId: string): Promise<DeployResult> {
 		await this.authService.authenticate();
 		return this.deployService.quickDeploy(deploymentId);
+	}
+
+	async fetchDeploymentStatus(deploymentId: string): Promise<DeployResult> {
+		await this.authService.authenticate();
+		return this.deployService.fetchDeploymentStatus(deploymentId);
+	}
+
+	async cancelDeployment(deploymentId: string): Promise<DeployResult> {
+		await this.authService.authenticate();
+		return this.deployService.cancelDeployment(deploymentId);
+	}
+
+	formatDeployResponse(result: DeployResult): NormalizedDeployResponse {
+		return this.deployService.formatDeployResponse(result);
 	}
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import config from './config.js';
 import { SalesforceClient } from './SalesforceClient.js';
 import type { CommandArgsConfig } from './types/config.type.js';
 import type { DeployOptions } from './types/deployment.type.js';
+import type { NormalizedDeployResponse } from './services/DeployService.js';
 
 class CLI {
 	private program: Command;
@@ -35,12 +36,15 @@ class CLI {
 			.option('-r, --targetBranch <targetBranch>', 'Target branch or git ref for delta comparison', this.config.targetBranch)
 			.option('-v, --validateOnly', 'Validate only, do not deploy')
 			.option('-x, --exclude <types...>', 'List of metadata types to exclude')
-			.option('-t, --testLevel <level>', 'Specifies which tests are run as part of a deployment', 'NoTestRun');
+			.option('-t, --testLevel <level>', 'Specifies which tests are run as part of a deployment', 'NoTestRun')
+			.option('--reportFormat <format>', 'Output format (summary|json)', 'summary');
 	}
 
 	private setupCommands(): void {
 		this.setupQuickDeployCommand();
 		this.setupDeployCommand();
+		this.setupStatusCommand();
+		this.setupCancelCommand();
 	}
 
 	private setupQuickDeployCommand(): void {
@@ -54,7 +58,8 @@ class CLI {
 					const client = new SalesforceClient(updatedConfig);
 					console.log('Initiating quick deployment...');
 					const result = await client.quickDeploy(cmdOptions.quickDeployId);
-					console.log('Quick deployment completed:', result);
+					this.printReport(client.formatDeployResponse(result), updatedConfig.reportFormat);
+					this.failForTerminalError(result.status, 'Quick deployment failed');
 				} catch (error) {
 					this.handleError('Quick deployment failed', error);
 				}
@@ -80,9 +85,46 @@ class CLI {
 
 					// Initialize deployment
 					const result: any = await client.deploy(deployOptions);
-					console.log('Deployment completed:', result.id);
+					this.printReport(client.formatDeployResponse(result), updatedConfig.reportFormat);
+					this.failForTerminalError(result.status, 'Deployment failed');
 				} catch (error) {
 					this.handleError('Deployment failed', error);
+				}
+			});
+	}
+
+	private setupStatusCommand(): void {
+		this.program
+			.command('status')
+			.description('Get one-shot deployment status')
+			.requiredOption('--deployId <id>', 'Deployment ID')
+			.action(async (cmdOptions) => {
+				try {
+					const updatedConfig = this.getUpdatedConfig({ ...this.program.opts(), ...cmdOptions });
+					const client = new SalesforceClient(updatedConfig);
+					const result = await client.fetchDeploymentStatus(cmdOptions.deployId);
+					this.printReport(client.formatDeployResponse(result), updatedConfig.reportFormat);
+					this.failForTerminalError(result.status, 'Deployment status indicates terminal failure');
+				} catch (error) {
+					this.handleError('Status command failed', error);
+				}
+			});
+	}
+
+	private setupCancelCommand(): void {
+		this.program
+			.command('cancel')
+			.description('Cancel deployment by ID')
+			.requiredOption('--deployId <id>', 'Deployment ID')
+			.action(async (cmdOptions) => {
+				try {
+					const updatedConfig = this.getUpdatedConfig({ ...this.program.opts(), ...cmdOptions });
+					const client = new SalesforceClient(updatedConfig);
+					const result = await client.cancelDeployment(cmdOptions.deployId);
+					this.printReport(client.formatDeployResponse(result), updatedConfig.reportFormat);
+					this.failForTerminalError(result.status, 'Deployment cancel command failed');
+				} catch (error) {
+					this.handleError('Cancel command failed', error);
 				}
 			});
 	}
@@ -122,6 +164,20 @@ class CLI {
 			console.error('Unknown error:', error);
 		}
 		process.exit(1);
+	}
+
+	private printReport(report: NormalizedDeployResponse, reportFormat?: string): void {
+		if (reportFormat?.toLowerCase() === 'json') {
+			console.log(JSON.stringify(report, null, 2));
+			return;
+		}
+		console.log(report.summary);
+	}
+
+	private failForTerminalError(status: string, message: string): void {
+		if (status === 'Failed' || status === 'Canceled') {
+			throw new Error(`${message}: ${status}`);
+		}
 	}
 }
 

--- a/src/services/DeployService.ts
+++ b/src/services/DeployService.ts
@@ -2,6 +2,20 @@ import fs from 'fs';
 import { BaseService } from './BaseService.js';
 import type { DeployOptions, DeployResult } from '../types/deployment.type.js';
 
+const DEPLOY_ID_PATTERN = /^0Af[A-Za-z0-9]{12,15}$/;
+
+export interface NormalizedDeployResponse {
+  id: string;
+  done: boolean;
+  status: DeployResult['status'];
+  success: boolean;
+  canceled: boolean;
+  errorCount: number;
+  testErrorCount: number;
+  componentErrorCount: number;
+  summary: string;
+}
+
 export class DeployService extends BaseService {
   async quickDeploy(deploymentId: string): Promise<DeployResult> {
     try {
@@ -53,7 +67,7 @@ export class DeployService extends BaseService {
     const maxAttempts = 120;
 
     while (attempt < maxAttempts) {
-      const status = await this.getDeploymentStatus(deployId);
+      const status = await this.fetchDeploymentStatus(deployId);
       // console.table(status.details.componentFailures);
       if (status.numberComponentsDeployed === 0) console.log('Pending Deployment. ');
       
@@ -87,10 +101,48 @@ export class DeployService extends BaseService {
     throw new Error('Deployment timed out');
   }
 
-  private async getDeploymentStatus(deployId: string): Promise<DeployResult> {
+  async fetchDeploymentStatus(deployId: string): Promise<DeployResult> {
+    this.validateDeployId(deployId);
     const response = await this.fetchWithAuth(`${this.config.instanceUrl}/services/data/${this.config.sfVersion}/metadata/deployRequest/${deployId}?includeDetails=true`, { method: 'GET' });
     const data = (await response.json()) as { deployResult: DeployResult };
     return data.deployResult;
+  }
+
+  async cancelDeployment(deployId: string): Promise<DeployResult> {
+    this.validateDeployId(deployId);
+    const response = await this.fetchWithAuth(`${this.config.instanceUrl}/services/data/${this.config.sfVersion}/metadata/deployRequest/${deployId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cancelDeploy: true }),
+    });
+    const data = (await response.json()) as { deployResult?: DeployResult };
+
+    if (data.deployResult) {
+      return data.deployResult;
+    }
+
+    return this.fetchDeploymentStatus(deployId);
+  }
+
+  formatDeployResponse(result: DeployResult): NormalizedDeployResponse {
+    const componentErrorCount = result.numberComponentErrors ?? 0;
+    const testErrorCount = result.numberTestErrors ?? 0;
+    const errorCount = componentErrorCount + testErrorCount;
+    const canceled = result.status === 'Canceled';
+    const success = (result.status === 'Succeeded' || result.status === 'SucceededPartial') && !canceled;
+    const summary = `${result.status} | components ${result.numberComponentsDeployed}/${result.numberComponentsTotal} | tests ${result.numberTestsCompleted}/${result.numberTestsTotal} | errors ${errorCount}`;
+
+    return {
+      id: result.id,
+      done: result.done,
+      status: result.status,
+      success,
+      canceled,
+      errorCount,
+      testErrorCount,
+      componentErrorCount,
+      summary,
+    };
   }
 
   private async createDeployRequest(zipPath: string, options: Partial<DeployOptions>): Promise<string> {
@@ -130,5 +182,11 @@ export class DeployService extends BaseService {
 
   private wait(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private validateDeployId(deployId: string): void {
+    if (!DEPLOY_ID_PATTERN.test(deployId)) {
+      throw new Error(`Invalid deploy ID: ${deployId}`);
+    }
   }
 }

--- a/src/services/__tests__/DeployService.test.ts
+++ b/src/services/__tests__/DeployService.test.ts
@@ -27,7 +27,8 @@ describe('DeployService', () => {
 		coverageJson: 'coverage.json',
 		runTests: [],
 	};
-    const MOCK_DEPLOY_ID = 'mock-deploy-id';
+    const MOCK_DEPLOY_ID = '0Af123456789012';
+    const INVALID_DEPLOY_ID = 'bad-id';
     const MOCK_ZIP_PATH = './test.zip';
     const MOCK_ZIP_CONTENT = Buffer.from('test-zip-content');
     const MOCK_BASE64_ZIP = MOCK_ZIP_CONTENT.toString('base64');
@@ -208,6 +209,114 @@ describe('DeployService', () => {
             await expect(service.pollDeploymentStatus(MOCK_DEPLOY_ID))
                 .rejects
                 .toThrow('Deployment timed out');
+        });
+    });
+
+    describe('fetchDeploymentStatus', () => {
+        it('should fetch deployment status in one shot', async () => {
+            const mockResponse = {
+                ok: true,
+                json: async () => ({
+                    deployResult: {
+                        id: MOCK_DEPLOY_ID,
+                        status: 'Succeeded',
+                        done: true
+                    }
+                })
+            };
+            jest.spyOn(service as any, 'fetchWithAuth').mockResolvedValueOnce(mockResponse);
+
+            const result = await service.fetchDeploymentStatus(MOCK_DEPLOY_ID);
+            expect(result).toEqual({
+                id: MOCK_DEPLOY_ID,
+                status: 'Succeeded',
+                done: true
+            });
+        });
+
+        it('should reject invalid deployment IDs', async () => {
+            await expect(service.fetchDeploymentStatus(INVALID_DEPLOY_ID))
+                .rejects
+                .toThrow(`Invalid deploy ID: ${INVALID_DEPLOY_ID}`);
+        });
+    });
+
+    describe('cancelDeployment', () => {
+        it('should return deploy result from cancel endpoint', async () => {
+            const cancelResponse = {
+                ok: true,
+                json: async () => ({
+                    deployResult: {
+                        id: MOCK_DEPLOY_ID,
+                        status: 'Canceled',
+                        done: true
+                    }
+                })
+            };
+            jest.spyOn(service as any, 'fetchWithAuth').mockResolvedValueOnce(cancelResponse);
+
+            const result = await service.cancelDeployment(MOCK_DEPLOY_ID);
+            expect(result.status).toBe('Canceled');
+        });
+
+        it('should fallback to status fetch when cancel endpoint has no result', async () => {
+            const fetchWithAuthSpy = jest.spyOn(service as any, 'fetchWithAuth')
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({})
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: async () => ({
+                        deployResult: {
+                            id: MOCK_DEPLOY_ID,
+                            status: 'InProgress',
+                            done: false
+                        }
+                    })
+                });
+
+            const result = await service.cancelDeployment(MOCK_DEPLOY_ID);
+            expect(result.status).toBe('InProgress');
+            expect(fetchWithAuthSpy).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('formatDeployResponse', () => {
+        it('should normalize successful response', () => {
+            const response = service.formatDeployResponse({
+                id: MOCK_DEPLOY_ID,
+                done: true,
+                status: 'Succeeded',
+                numberComponentsDeployed: 10,
+                numberComponentsTotal: 10,
+                numberComponentErrors: 0,
+                numberTestsCompleted: 5,
+                numberTestsTotal: 5,
+                numberTestErrors: 0,
+                details: { componentFailures: [] }
+            });
+
+            expect(response.success).toBe(true);
+            expect(response.errorCount).toBe(0);
+        });
+
+        it('should normalize failed response', () => {
+            const response = service.formatDeployResponse({
+                id: MOCK_DEPLOY_ID,
+                done: true,
+                status: 'Failed',
+                numberComponentsDeployed: 8,
+                numberComponentsTotal: 10,
+                numberComponentErrors: 2,
+                numberTestsCompleted: 3,
+                numberTestsTotal: 5,
+                numberTestErrors: 1,
+                details: { componentFailures: [] }
+            });
+
+            expect(response.success).toBe(false);
+            expect(response.errorCount).toBe(3);
         });
     });
 

--- a/src/types/config.type.ts
+++ b/src/types/config.type.ts
@@ -16,6 +16,7 @@ export interface CommandArgsConfig {
 	cliVersion: string;
 	cliOuputFolder: string;
 	quickDeployId?: string;
+	reportFormat?: 'summary' | 'json';
 	testLevel: 'NoTestRun' | 'RunLocalTests' | 'RunAllTestsInOrg' | 'RunSpecifiedTests';
 	coverageJson: string;
 	runTests: string[];


### PR DESCRIPTION
### Motivation
- Provide one-shot deployment operations (`status` and `cancel`) so users and CI can inspect or cancel deployments without running the full polling flow.
- Reuse a single normalized report output and add a `--reportFormat` option to allow machine-readable (`json`) or human (`summary`) output.
- Ensure terminal failures (`Failed`/`Canceled`) produce non-zero exits so CI pipelines can fail fast.

### Description
- Added `status --deployId <id>` and `cancel --deployId <id>` CLI commands and a global `--reportFormat <summary|json>` option in `src/cli.ts`, and implemented `printReport` and `failForTerminalError` helpers.
- Extended `DeployService` (`src/services/DeployService.ts`) with public methods `fetchDeploymentStatus`, `cancelDeployment`, `formatDeployResponse`, and `validateDeployId`, and made polling reuse the new one-shot fetch method.
- Exposed the new deploy operations and formatter via `SalesforceClient` (`src/SalesforceClient.ts`) so the CLI can call `fetchDeploymentStatus`, `cancelDeployment`, and `formatDeployResponse` uniformly.
- Added `reportFormat` to `CommandArgsConfig` (`src/types/config.type.ts`) and expanded tests in `src/services/__tests__/DeployService.test.ts` covering status success, invalid ID handling, cancel behaviors (endpoint result and fallback), and response normalization.

### Testing
- Ran unit tests with `npm test -- --runInBand src/services/__tests__/DeployService.test.ts`, and the suite passed (15 tests passed).
- Ran a TypeScript build with `npm run build`, and the project compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e7bbc1c88327a7cd2f9caadc0eee)